### PR TITLE
Fix bug in assigner where it wasn't recognizing assignee list changes

### DIFF
--- a/assigner.py
+++ b/assigner.py
@@ -197,7 +197,7 @@ def autoassign(bapi, cfg, dry_run):
     try:
         with open(cfg.get('cache'), 'rb') as f:
             (assign_list, assign_hash) = pickle.load(f)
-            if set(assign_list) != set(assign_hash):
+            if set(assign_list) != set(cfg.get('assignees')):
                 logger.info("List of assignees changed, resetting list!")
                 reset_assignees = True
     except FileNotFoundError:


### PR DESCRIPTION
I believe this fixes #26, by comparing assign_list against the config, not itself.