### PR TITLE
Temporarily disable CASA integration while we troubleshoot

### DIFF
--- a/assigner.py
+++ b/assigner.py
@@ -277,7 +277,7 @@ def main():
 
     autoassign(bapi, config['bugzilla']['rra'], args.dry_run)
     autoassign(bapi, config['bugzilla']['va'], args.dry_run)
-    autocasa(bapi, capi, config['bugzilla'], config['casa'], args.dry_run)
+    #autocasa(bapi, capi, config['bugzilla'], config['casa'], args.dry_run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
CASA API integration is broken for whatever reason.   This PR simply disables the CASA functionality until we can fix it, while allowing us to keep RRA/VA BMO bug auto-triage in the mean time while I troubleshoot.