### PR TITLE
[WIP] Add staging config stub as prep for stage integration

### DIFF
--- a/config-stage.yaml
+++ b/config-stage.yaml
@@ -1,0 +1,22 @@
+bugzilla:
+    url: "https://bugzilla.allizom.org/rest/"
+    creator: "infosec+rra2json@mozilla.com"
+    rra:
+        product: "Enterprise Information Security"
+        component: "Rapid Risk Analysis"
+        assignees:
+            - jclaudius@mozilla.com
+            - tweir@mozilla.com
+            - culucenk@mozilla.com
+        cache: "/tmp/rra_assignees_stage.pickle"
+    va:
+        product: "Enterprise Information Security"
+        component: "Vulnerability Assessment"
+        assignees:
+            - jclaudius@mozilla.com
+            - culucenk@mozilla.com
+        cache: "/tmp/va_assignees_stage.pickle"
+casa:
+    url: "https://INSERT_CASA_STAGE_HOST/api/v1/"
+    lookup_period_in_days: 30
+    bot_email: 'INSERT_STAGE_BIZBOT_EMAIL_ADDRESS'


### PR DESCRIPTION
Fixes https://github.com/mozilla/infosec-risk-management-bugzilla/issues/34

Note that this is a WIP - Work in Progress and it lacks essential details and other missing pieces, such as the following...

- [ ] Valid CASA staging endpoint and API token we can hit publicly (will come from Bizterra)
- [ ] Valid BMO dev/stage endpoint and APO token (we can gen this ourselves)
- [ ] CASA/BMO API tokens loaded into job runner (we can do this once we have essential bits)
- [ ] Additional job added for stage only, perhaps with larger distribution group to alert on staging failures (we can do this once we have essential bits)

mvk will be discussing staging capabilities with CASA soon, once we have more details that will inform the progress of this PR.