### PR TITLE
Change to auto-assign Firefox related projects/vendors to FoxSec

### DIFF
--- a/assigner.py
+++ b/assigner.py
@@ -355,14 +355,12 @@ def autoassign(bapi, capi, bcfg, ccfg, fcfg, dry_run):
                 # If it has "Product Line: Firefox" then this should be assigned to FoxSec
                 if "firefox" in product_line.lower():
                     # This is a Firefox-related project/vendor, should be handled by FoxSec
-                    # TODO: Change the email address later
                     assignee = fcfg.get("assignee")
             # RRA requested manually in Bugzilla
             else:
                 comment_0 = bapi.get_comments(bug.get("id"))["bugs"][str(bug.get("id"))]["comments"][0]["text"]
                 if any(keyword in comment_0.lower() for keyword in foxsec_keywords):
                     # This is a Firefox-related project/vendor, should be handled by FoxSec
-                    # TODO: Change the email address later
                     assignee = fcfg.get("assignee")
 
             bug_up = bugzilla.DotDict()

--- a/casa.py
+++ b/casa.py
@@ -87,12 +87,16 @@ class Casa:
                 parsed["project_id"] = parsed.get("url").split("/")[-1]
             elif parse_next == "creator":
                 parsed["creator"] = l.split("- ")[1]
+            elif parse_next == "product_line":
+                parsed["product_line"] = l.split("- ")[1]
 
             # Setup next-line parser
             if l == "Biztera URL:":
                 parse_next = "url"
             elif l == "Project Creator:":
                 parse_next = "creator"
+            elif l == "Product Line:":
+                parse_next = "product_line"
             else:
                 parse_next = None
 

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ casa:
     bot_email: 'bizbot@biztera.com'
 foxsec:
     assignee:
-        - cag@mozilla.com
+        - jvehent@mozilla.com
     keywords:
         - fxa
         - firefox

--- a/config.yaml
+++ b/config.yaml
@@ -21,18 +21,18 @@ casa:
     bot_email: 'bizbot@biztera.com'
 foxsec:
     assignee:
-        - culucenk@mozilla.com
+        - cag@mozilla.com
     keywords:
-        - FxA
-        - Firefox
-        - Balrog
-        - Normandy
-        - Telemetry
-        - FxSend
-        - FxMonitor
-        - FPN
-        - Taskcluster
+        - fxa
+        - firefox
+        - balrog
+        - normandy
+        - telemetry
+        - fxsend
+        - fxmonitor
+        - fpn
+        - taskcluster
         - shipit
-        - Sentry
-        - Phabricator
-        - Lando
+        - sentry
+        - phabricator
+        - lando

--- a/config.yaml
+++ b/config.yaml
@@ -5,20 +5,6 @@ bugzilla:
     rra:
         product: "Enterprise Information Security"
         component: "Rapid Risk Analysis"
-        keywords:
-            - FxA
-            - Firefox
-            - Balrog
-            - Normandy
-            - Telemetry
-            - FxSend
-            - FxMonitor
-            - FPN
-            - Taskcluster
-            - shipit
-            - Sentry
-            - Phabricator
-            - Lando
         assignees:
             - culucenk@mozilla.com
             - tweir@mozilla.com
@@ -33,3 +19,20 @@ casa:
     url: "https://biztera.com/api/v1/"
     lookup_period_in_days: 30
     bot_email: 'bizbot@biztera.com'
+foxsec:
+    assignee:
+        - culucenk@mozilla.com
+    keywords:
+        - FxA
+        - Firefox
+        - Balrog
+        - Normandy
+        - Telemetry
+        - FxSend
+        - FxMonitor
+        - FPN
+        - Taskcluster
+        - shipit
+        - Sentry
+        - Phabricator
+        - Lando

--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ casa:
     lookup_period_in_days: 30
     bot_email: 'bizbot@biztera.com'
 foxsec:
-    assignee:
+    assignees:
         - jvehent@mozilla.com
     keywords:
         - fxa

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,20 @@ bugzilla:
     rra:
         product: "Enterprise Information Security"
         component: "Rapid Risk Analysis"
+        keywords:
+            - FxA
+            - Firefox
+            - Balrog
+            - Normandy
+            - Telemetry
+            - FxSend
+            - FxMonitor
+            - FPN
+            - Taskcluster
+            - shipit
+            - Sentry
+            - Phabricator
+            - Lando
         assignees:
             - culucenk@mozilla.com
             - tweir@mozilla.com

--- a/contrib/bugzilla.service
+++ b/contrib/bugzilla.service
@@ -7,5 +7,6 @@ WorkingDirectory=/home/ec2-user/infosec-risk-management-bugzilla/
 ExecStart=/usr/bin/git pull -r origin master
 ExecStart=/home/ec2-user/infosec-risk-management-bugzilla/venv/bin/pip3 install -r requirements.txt
 ExecStart=/home/ec2-user/infosec-risk-management-bugzilla/venv/bin/python3 ./assigner.py -d --module casa --configfile ./config.yaml
-ExecStart=/home/ec2-user/infosec-risk-management-bugzilla/venv/bin/python3 ./assigner.py -d --module bugzilla --configfile ./config.yaml
+ExecStart=/home/ec2-user/infosec-risk-management-bugzilla/venv/bin/python3 ./assigner.py -d --module rra --configfile ./config.yaml
+ExecStart=/home/ec2-user/infosec-risk-management-bugzilla/venv/bin/python3 ./assigner.py -d --module va --configfile ./config.yaml
 User=ec2-user


### PR DESCRIPTION
The aim of this PR is to auto-assign RRA requests that are triggered via CASA to FoxSec team, _only if_ the product line is "Firefox". Currently this is done manually by the people in the rotation. This could be a small improvement.

Marking as draft for now as I'd like to test it first.