### PR TITLE
Change needinfo to require gene instead of jonathan

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 bugzilla:
     url: "https://bugzilla.mozilla.org/rest/"
     creator: "infosec+rra2json@mozilla.com"
-    needinfo: "jclaudius@mozilla.com"
+    needinfo: "gene@mozilla.com"
     rra:
         product: "Security Assurance"
         component: "Rapid Risk Analysis"


### PR DESCRIPTION
This comes into play when a bugzilla ticket is marked WONTFIX or INCOMPLETE, gene will now be needinfod